### PR TITLE
make libraries compatible with non-mainet networks

### DIFF
--- a/tests/WebAuthn_forge/src/ECCMath.sol
+++ b/tests/WebAuthn_forge/src/ECCMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 /**
  * @title ECCMath
@@ -51,17 +51,17 @@ library ECCMath {
         r = 1;
         uint bit = 2 ** 255;
         assembly {
-            for{} gt(bit,0) {}{ 
+            for{} gt(bit,0) {}{
                 r := mulmod(mulmod(r, r, m), exp(b, iszero(iszero(and(e, bit)))), m)
                 r := mulmod(mulmod(r, r, m), exp(b, iszero(iszero(and(e, div(bit, 2))))), m)
                 r := mulmod(mulmod(r, r, m), exp(b, iszero(iszero(and(e, div(bit, 4))))), m)
                 r := mulmod(mulmod(r, r, m), exp(b, iszero(iszero(and(e, div(bit, 8))))), m)
                 bit := div(bit, 16)
-               
+
         }
         }
     }
-  
+
     ///  @dev Converts a point (Px, Py, Pz) expressed in Jacobian coordinates to affine coordinates
     /// Mutates P.
     /// @param P The point.

--- a/tests/WebAuthn_forge/src/ECops.sol
+++ b/tests/WebAuthn_forge/src/ECops.sol
@@ -1,24 +1,24 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 // Orbs implementation
 library ECops {
-    
+
     uint256 constant n = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF;
     //short weierstrass first coefficient
     uint256 constant a = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC;
     //short weierstrass second coefficient
     uint256 constant b = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B;
-    
-    
- //   uint256 constant n = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47;   
+
+
+ //   uint256 constant n = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47;
    // uint256 constant a = 0;
   //  uint256 constant b = 3;
-    
 
-    
 
-    
-    // Returns the inverse in the field of modulo n 
+
+
+
+    // Returns the inverse in the field of modulo n
     function inverse(uint256 num) public pure
         returns(uint256 invNum)
     {
@@ -36,8 +36,8 @@ library ECops {
 
         invNum = t;
     }
-    
-    
+
+
     // Transform from affine to projective coordinates
     function toProjectivePoint(uint256 x0, uint256 y0) public pure
         returns(uint256 x1, uint256 y1, uint256 z1)
@@ -46,8 +46,8 @@ library ECops {
         x1 = mulmod(x0, z1, n);
         y1 = mulmod(y0, z1, n);
     }
-    
-    
+
+
     // Transform from projective to affine coordinates
     function toAffinePoint(uint256 x0, uint256 y0, uint256 z0) public pure
         returns(uint256 x1, uint256 y1)
@@ -60,7 +60,7 @@ library ECops {
 
 
     // Returns the zero curve in proj coordinates
-    function zeroProj() public pure 
+    function zeroProj() public pure
         returns(uint256 x, uint256 y, uint256 z)
     {
         return (0,0,1);
@@ -68,7 +68,7 @@ library ECops {
 
 
     // Returns the zero curve in affine coordinates
-    function zeroAffine() public pure 
+    function zeroAffine() public pure
         returns(uint256 x, uint256 y)
     {
         return (0,0);
@@ -84,7 +84,7 @@ library ECops {
         }
         return false;
     }
-    
+
 
     // Double an elliptic curve point
     // https://www.nayuki.io/page/elliptic-curve-point-addition-in-projective-coordinates
@@ -145,17 +145,17 @@ library ECops {
 
         if (isZeroCurve(x0, y0)) {
             return (x1, y1, z1);
-        } 
+        }
         else if (isZeroCurve(x1, y1)) {
             return (x0, y0, z0);
         }
-        
+
         t0 = mulmod(y0, z1, n);
         t1 = mulmod(y1, z0, n);
-        
+
         u0 = mulmod(x0, z1, n);
         u1 = mulmod(x1, z0, n);
-        
+
         if (u0 == u1) {
             if (t0 == t1) {
                 return twiceProj(x0, y0, z0);
@@ -164,13 +164,13 @@ library ECops {
                 return zeroProj();
             }
         }
-        
+
         (x2, y2, z2) = addProj2(mulmod(z0, z1, n), u0, u1, t1, t0);
     }
-    
-    
+
+
     // An help function to split addProj so it won't have too many local variables
-    function addProj2(uint256 v, uint256 u0, uint256 u1, 
+    function addProj2(uint256 v, uint256 u0, uint256 u1,
                       uint256 t1, uint256 t0) private pure
         returns(uint256 x2, uint256 y2, uint256 z2)
     {
@@ -189,7 +189,7 @@ library ECops {
         u1 = addmod(u1, u0, n);
         u1 = mulmod(u1, u2, n);
         w = addmod(w, n-u1, n);
-        
+
         x2 = mulmod(u, w, n);
 
         u3 = mulmod(u2, u, n);
@@ -202,7 +202,7 @@ library ECops {
 
         z2 = mulmod(u3, v, n);
     }
-    
+
 
     // Add two elliptic curve points (affine coordinates)
     function add(uint256 x0, uint256 y0,
@@ -228,7 +228,7 @@ library ECops {
 
 
     // Multiple an elliptic curve point in a 2 power base (i.e., (2^exp)*P))
-    function multiplyPowerBase2(uint256 x0, uint256 y0, 
+    function multiplyPowerBase2(uint256 x0, uint256 y0,
                                 uint exp) public pure
         returns(uint256 x1, uint256 y1)
     {
@@ -248,7 +248,7 @@ library ECops {
                             uint scalar) public pure
         returns(uint256 x1, uint256 y1)
     {
-        
+
 
         if(scalar == 0) {
             return zeroAffine();
@@ -285,5 +285,5 @@ library ECops {
 
         return toAffinePoint(x1, y1, z1);
     }
-    
+
 }

--- a/tests/WebAuthn_forge/src/FCL_Webauthn.sol
+++ b/tests/WebAuthn_forge/src/FCL_Webauthn.sol
@@ -18,7 +18,7 @@
 // Code is optimized for a=-3 only curves with prime order, constant like -1, -2 shall be replaced
 // if ever used for other curve than sec256R1
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import {Base64} from "openzeppelin-contracts/contracts/utils/Base64.sol";
 import {FCL_Elliptic_ZZ} from "./FCL_elliptic.sol";

--- a/tests/WebAuthn_forge/src/FCL_elliptic.sol
+++ b/tests/WebAuthn_forge/src/FCL_elliptic.sol
@@ -19,7 +19,7 @@
 // Code is optimized for a=-3 only curves with prime order, constant like -1, -2 shall be replaced
 // if ever used for other curve than sec256R1
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 library FCL_Elliptic_ZZ {
     // Set parameters for curve sec256r1.
@@ -255,7 +255,7 @@ library FCL_Elliptic_ZZ {
                 for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
                     index := sub(index, 1)
                     T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
-                   
+
                 } {}
                 zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
 
@@ -414,7 +414,7 @@ library FCL_Elliptic_ZZ {
             }
             assembly {
                 extcodecopy(dataPointer, T, mload(T), 64)
-	        let index := sub(zz,1) 
+	        let index := sub(zz,1)
                 X := mload(T)
                 let Y := mload(add(T, 32))
                 let zzz := 1
@@ -535,40 +535,40 @@ library FCL_Elliptic_ZZ {
         } //end unchecked
     }
 
-    //compute the wnaf reprensentation of a positive scalar		
-    function ecZZ_wnaf(uint256 scalar) public returns (bytes memory wnaf, uint256 length) 
+    //compute the wnaf reprensentation of a positive scalar
+    function ecZZ_wnaf(uint256 scalar) public returns (bytes memory wnaf, uint256 length)
     {
       bytes memory temp=new bytes(300);
       uint length=0;
       uint8 ki=0;
-      
+
       while(scalar>0){
        if(scalar&1==1){
          ki=uint8(scalar%256);
          temp[length]=bytes1(ki);
          if(ki>=128){
-          scalar+=256; 
+          scalar+=256;
          }
          scalar-=uint256(ki);
-         
+
        }
        scalar=scalar/2;
        length=length+1;
       }
-      
-    
-    
+
+
+
       return (temp, length);
     }
-	
-    	
-	
+
+
+
       //Taking scalars directly interleaved to avoid to perform it in contract
       function ecZZ_mulmuladd_interleaved(uint256 scalar_high, uint256 scalar_low, address dataPointer)
         internal
         returns (uint256 X /*, uint Y*/ )
     {
-        
+
         unchecked {
             uint256 zz; // third and  coordinates of the point
 	    if((scalar_high &scalar_low)==0)
@@ -591,8 +591,8 @@ library FCL_Elliptic_ZZ {
                  scalar_high=scalar_low;//first test prevent infinite loop on (0,0) input
                  zz=248;
                 }
-            
-            
+
+
             assembly {
                 extcodecopy(dataPointer, T, mload(T), 64)
 	        let index := zz
@@ -601,7 +601,7 @@ library FCL_Elliptic_ZZ {
                 let zzz := 1
                 zz := 1
 		let highdone:=0
-		
+
                 //loop over 1/4 of scalars thx to Shamir's trick over 8 points
                 for { } gt(index, 0) { index := sub(index, 8) } {
                 	//inline Double
@@ -624,7 +624,7 @@ library FCL_Elliptic_ZZ {
                         /* compute element to access in precomputed table */
                     }
                     {
-                       
+
                         let T1 := and(shr(index, scalar_high), 0xff)
                         //tbd: check validity of formulae with (0,1) to remove conditional jump
                         if iszero(T1) {
@@ -641,7 +641,7 @@ library FCL_Elliptic_ZZ {
                             index:=248
                           }
                         }
-                         
+
                     }
 
                     {
@@ -694,7 +694,7 @@ library FCL_Elliptic_ZZ {
                         X := addmod(addmod(mulmod(y2, y2, p), sub(p, T1), p), mulmod(minus_2, zz1, p), p)
                         Y := addmod(mulmod(addmod(zz1, sub(p, X), p), y2, p), mulmod(Y, T1, p), p)
                     }
-                    
+
                 } //end loop
                 mstore(add(T, 0x60), zz)
 
@@ -716,7 +716,7 @@ library FCL_Elliptic_ZZ {
                 X := mulmod(X, zz, p) //X/zz
             }
         } //end unchecked
-    }	
+    }
 
 
 
@@ -887,7 +887,7 @@ library FCL_Elliptic_ZZ {
         internal
         returns (bool)
     {
-        
+
 
          uint256 X;
 
@@ -900,7 +900,7 @@ library FCL_Elliptic_ZZ {
 
         return X == 0;
     } //end  ecdsa_precomputed_verify()
-    
+
     /**
      * @dev ECDSA verification using a precomputed table of multiples of P and Q appended at end of contract at address endcontract
      *     generation of contract bytecode for precomputations is done using sagemath code

--- a/tests/WebAuthn_forge/src/FCL_in_Numerology.sol
+++ b/tests/WebAuthn_forge/src/FCL_in_Numerology.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 
 /// @title Numerology: A Solidity library for fast ECC arithmetics using curve secp256k1
@@ -12,7 +12,7 @@ library Numerology {
     /// @param Q An EC point in Jacobian coordinates
     /// @return true if P and Q represent the same point in affine coordinates; false otherwise
     function eqJacobian(
-    	uint256[3] memory P, 
+    	uint256[3] memory P,
     	uint256[3] memory Q
     ) internal pure returns(bool) {
         uint256 p = fieldOrder;
@@ -36,7 +36,7 @@ library Numerology {
         uint256 Q_z_cubed = mulmod(Q_z_squared, Qz, p);
         uint256 P_z_cubed = mulmod(P_z_squared, Pz, p);
         return mulmod(P[1], Q_z_cubed, p) == mulmod(Q[1], P_z_cubed, p);
-    
+
     }
 
     /// @notice Equality test of two points, in affine and Jacobian coordinates respectively
@@ -44,7 +44,7 @@ library Numerology {
     /// @param Q An EC point in Jacobian coordinates
     /// @return true if P and Q represent the same point in affine coordinates; false otherwise
     function eqAffineJacobian(
-    	uint256[2] memory P, 
+    	uint256[2] memory P,
     	uint256[3] memory Q
     ) internal pure returns(bool){
         uint256 Qz = Q[2];
@@ -55,17 +55,17 @@ library Numerology {
         uint256 p = fieldOrder;
         uint256 Q_z_squared = mulmod(Qz, Qz, p);
         return mulmod(P[0], Q_z_squared, p) == Q[0] && mulmod(P[1], mulmod(Q_z_squared, Qz, p), p) == Q[1];
-    
+
     }
 
-  
+
     /// @notice Addition of two points in Jacobian coordinates
     /// @dev Based on the addition formulas from http://www.hyperelliptic.org/EFD/g1p/auto-code/shortw/jacobian-0/addition/add-2001-b.op3
     /// @param P An EC point in Jacobian coordinates
     /// @param Q An EC point in Jacobian coordinates
     /// @return R An EC point in Jacobian coordinates with the sum, represented by an array of 3 uint256
     function addJac(
-    	uint256[3] memory P, 
+    	uint256[3] memory P,
     	uint256[3] memory Q
     ) internal pure returns (uint256[3] memory R) {
 
@@ -79,7 +79,7 @@ library Numerology {
         uint256 zz1 = mulmod(P[2], P[2], p);
         uint256 zz2 = mulmod(Q[2], Q[2], p);
         uint256 a   = mulmod(P[0], zz2, p);
-        uint256 c   = mulmod(P[1], mulmod(Q[2], zz2, p), p);   
+        uint256 c   = mulmod(P[1], mulmod(Q[2], zz2, p), p);
         uint256 t0  = mulmod(Q[0], zz1, p);
         uint256 t1  = mulmod(Q[1], mulmod(P[2], zz1, p), p);
 
@@ -102,7 +102,7 @@ library Numerology {
     /// @param P An EC point in Jacobian coordinates. The result is returned here.
     /// @param Q An EC point in Jacobian coordinates
     function addJacobianMutates(
-    	uint[3] memory P, 
+    	uint[3] memory P,
     	uint[3] memory Q
     ) pure internal {
 
@@ -126,14 +126,14 @@ library Numerology {
 
         zz = mulmod(Qz, Qz, p);
         uint256 a   = mulmod(P[0], zz, p);
-        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p);   
-        
+        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p);
+
 
         if ((a == t0) && (c == t1)){
             doubleMutates(P);
             return;
         }
-        
+
         t1   = addmod(t1, p-c, p); // d = t1 - c
         uint256 b = addmod(t0, p-a, p); // b = t0 - a
         uint256 e = mulmod(b, b, p); // e = b^2
@@ -151,7 +151,7 @@ library Numerology {
     /// @param P An EC point in Jacobian coordinates. The result is returned here.
     /// @param Q An EC point in Jacobian coordinates
     function subJacobianMutates(
-    	uint[3] memory P, 
+    	uint[3] memory P,
     	uint[3] memory Q
     ) pure internal {
         uint256 Pz = P[2];
@@ -173,13 +173,13 @@ library Numerology {
 
         zz = mulmod(Qz, Qz, p);
         uint256 a   = mulmod(P[0], zz, p);
-        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p); 
+        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p);
 
         if ((a == t0) && (c == t1)){
             P[2] = 0;
             return;
         }
-        
+
         t1   = addmod(t1, p-c, p); // d = t1 - c
         uint256 b = addmod(t0, p-a, p); // b = t0 - a
         uint256 e = mulmod(b, b, p); // e = b^2
@@ -198,7 +198,7 @@ library Numerology {
     /// @param Q An EC point in affine coordinates
     /// @return R An EC point in Jacobian coordinates with the sum, represented by an array of 3 uint256
     function addAffineJacobian(
-    	uint[2] memory P, 
+    	uint[2] memory P,
     	uint[2] memory Q
     ) internal pure returns (uint[3] memory R) {
 
@@ -222,8 +222,8 @@ library Numerology {
     }
 
     /// @notice Point doubling in Jacobian coordinates
-    /// @param P An EC point in Jacobian coordinates. 
-    /// @return Q An EC point in Jacobian coordinates   
+    /// @param P An EC point in Jacobian coordinates.
+    /// @return Q An EC point in Jacobian coordinates
     function doubleJacobian(uint[3] memory P) internal pure returns (uint[3] memory Q) {
         uint256 z = P[2];
         if (z == 0)
@@ -257,9 +257,9 @@ library Numerology {
         P[1] = addmod(mulmod(m, addmod(s, p - t, p), p), mulmod(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffff7ffffe17, mulmod(_4yy, _4yy, p), p), p);
         P[2] = mulmod(_2y, z, p);
     }
-    
+
     function _lookup_sim_mul(
-    	uint256[3][4][4] memory iP, 
+    	uint256[3][4][4] memory iP,
     	uint256[4] memory P_Q
     ) internal pure {
         uint256 p = fieldOrder;
@@ -271,7 +271,7 @@ library Numerology {
         // P1 Lookup Table
         iPj = iP[0];
         iPj[0] = [P_Q[0], P_Q[1], 1];  						// P1
-        
+
         double = doubleJacobian(iPj[0]);
         iPj[1] = addJac(double, iPj[0]);
         iPj[2] = addJac(double, iPj[1]);
@@ -306,7 +306,7 @@ library Numerology {
     /// @return ptr : The pointer to the first coefficient
     /// @return length :  the total length of the array
     function _wnaf(int256 d) internal pure returns (uint256 ptr, uint256 length){
-    
+
         int sign = d < 0 ? -1 : int(1);
         uint256 k = uint256(sign * d);
 
@@ -326,30 +326,30 @@ library Numerology {
                 length := add(length, 1)
                 k := div(k, 2)
             }
-            //log3(ptr, 1, 0xfabadaacabada, d, length)    
+            //log3(ptr, 1, 0xfabadaacabada, d, length)
         }
 
         return (ptr, length);
     }
 
-    /// @notice Simultaneous multiplication of the form kP + lQ. 
+    /// @notice Simultaneous multiplication of the form kP + lQ.
     /// @dev Scalars k and l are expected to be decomposed such that k = k1 + k2 λ, and l = l1 + l2 λ,
     /// where λ is specific to the endomorphism of the curve
     /// @param k_l An array with the decomposition of k and l values, i.e., [k1, k2, l1, l2]
     /// @param P_Q An array with the affine coordinates of both P and Q, i.e., [P1, P2, Q1, Q2]
     function _sim_mul(
-    	int256[4] memory k_l, 
+    	int256[4] memory k_l,
     	uint256[4] memory P_Q
     ) internal pure returns (uint[3] memory Q) {
 
     	require(
-    		is_on_curve(P_Q[0], P_Q[1]) && is_on_curve(P_Q[2], P_Q[3]), 
+    		is_on_curve(P_Q[0], P_Q[1]) && is_on_curve(P_Q[2], P_Q[3]),
     		"Invalid points"
     	);
 
         uint256[4] memory wnaf;
         uint256 max_count = 0;
-        uint256 count = 0;        
+        uint256 count = 0;
 
         for(uint j=0; j<4; j++){
             (wnaf[j], count) = _wnaf(k_l[j]);
@@ -361,16 +361,16 @@ library Numerology {
         Q = _sim_mul_wnaf(wnaf, max_count, P_Q);
     }
 
-    
+
     function _sim_mul_wnaf(
-    	uint256[4] memory wnaf_ptr, 
-    	uint256 length, 
+    	uint256[4] memory wnaf_ptr,
+    	uint256 length,
     	uint256[4] memory P_Q
     ) internal pure returns (uint[3] memory Q) {
         uint256[3][4][4] memory iP;
         _lookup_sim_mul(iP, P_Q);
 
-        // LOOP 
+        // LOOP
         uint256 i = length;
         uint256 ki;
         uint256 ptr;
@@ -399,7 +399,7 @@ library Numerology {
                 subJacobianMutates(Q, iP[1][(15 - ki) / 2]);
             } else if (ki > 0) {
                 addJacobianMutates(Q, iP[1][(ki - 1) / 2]);
-            } 
+            }
 
             ptr = wnaf_ptr[2] + i;
             assembly {
@@ -410,7 +410,7 @@ library Numerology {
                 subJacobianMutates(Q, iP[2][(15 - ki) / 2]);
             } else if (ki > 0) {
                 addJacobianMutates(Q, iP[2][(ki - 1) / 2]);
-            } 
+            }
 
             ptr = wnaf_ptr[3] + i;
             assembly {
@@ -421,8 +421,8 @@ library Numerology {
                 subJacobianMutates(Q, iP[3][(15 - ki) / 2]);
             } else if (ki > 0) {
                 addJacobianMutates(Q, iP[3][(ki - 1) / 2]);
-            } 
-            
+            }
+
         }
     }
 
@@ -444,10 +444,10 @@ library Numerology {
 
     // https://ethresear.ch/t/you-can-kinda-abuse-ecrecover-to-do-ecmul-in-secp256k1-today/2384/4
     function ecmulVerify(
-    	uint256 x1, 
-    	uint256 y1, 
-    	uint256 scalar, 
-    	uint256 qx, 
+    	uint256 x1,
+    	uint256 y1,
+    	uint256 scalar,
+    	uint256 qx,
     	uint256 qy
     ) internal pure returns(bool) {
 	    uint256 curve_order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
@@ -462,8 +462,8 @@ library Numerology {
     /// @param _pointY The Y coordinate of an EC point in affine representation
     /// @return true iff _pointSign and _pointX are the compressed representation of (_pointX, _pointY)
 	function check_compressed_point(
-		uint8 _pointSign, 
-		uint256 _pointX, 
+		uint8 _pointSign,
+		uint256 _pointX,
 		uint256 _pointY
 	) internal pure returns(bool) {
 		bool correct_sign = _pointY % 2 == _pointSign - 2;

--- a/tests/WebAuthn_forge/src/Numerology.sol
+++ b/tests/WebAuthn_forge/src/Numerology.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 
 /// @title Numerology: A Solidity library for fast ECC arithmetics using curve secp256k1
@@ -12,7 +12,7 @@ library Numerology {
     /// @param Q An EC point in Jacobian coordinates
     /// @return true if P and Q represent the same point in affine coordinates; false otherwise
     function eqJacobian(
-    	uint256[3] memory P, 
+    	uint256[3] memory P,
     	uint256[3] memory Q
     ) internal pure returns(bool) {
         uint256 p = fieldOrder;
@@ -36,7 +36,7 @@ library Numerology {
         uint256 Q_z_cubed = mulmod(Q_z_squared, Qz, p);
         uint256 P_z_cubed = mulmod(P_z_squared, Pz, p);
         return mulmod(P[1], Q_z_cubed, p) == mulmod(Q[1], P_z_cubed, p);
-    
+
     }
 
     /// @notice Equality test of two points, in affine and Jacobian coordinates respectively
@@ -44,7 +44,7 @@ library Numerology {
     /// @param Q An EC point in Jacobian coordinates
     /// @return true if P and Q represent the same point in affine coordinates; false otherwise
     function eqAffineJacobian(
-    	uint256[2] memory P, 
+    	uint256[2] memory P,
     	uint256[3] memory Q
     ) internal pure returns(bool){
         uint256 Qz = Q[2];
@@ -55,17 +55,17 @@ library Numerology {
         uint256 p = fieldOrder;
         uint256 Q_z_squared = mulmod(Qz, Qz, p);
         return mulmod(P[0], Q_z_squared, p) == Q[0] && mulmod(P[1], mulmod(Q_z_squared, Qz, p), p) == Q[1];
-    
+
     }
 
-  
+
     /// @notice Addition of two points in Jacobian coordinates
     /// @dev Based on the addition formulas from http://www.hyperelliptic.org/EFD/g1p/auto-code/shortw/jacobian-0/addition/add-2001-b.op3
     /// @param P An EC point in Jacobian coordinates
     /// @param Q An EC point in Jacobian coordinates
     /// @return R An EC point in Jacobian coordinates with the sum, represented by an array of 3 uint256
     function addJac(
-    	uint256[3] memory P, 
+    	uint256[3] memory P,
     	uint256[3] memory Q
     ) internal pure returns (uint256[3] memory R) {
 
@@ -79,7 +79,7 @@ library Numerology {
         uint256 zz1 = mulmod(P[2], P[2], p);
         uint256 zz2 = mulmod(Q[2], Q[2], p);
         uint256 a   = mulmod(P[0], zz2, p);
-        uint256 c   = mulmod(P[1], mulmod(Q[2], zz2, p), p);   
+        uint256 c   = mulmod(P[1], mulmod(Q[2], zz2, p), p);
         uint256 t0  = mulmod(Q[0], zz1, p);
         uint256 t1  = mulmod(Q[1], mulmod(P[2], zz1, p), p);
 
@@ -102,7 +102,7 @@ library Numerology {
     /// @param P An EC point in Jacobian coordinates. The result is returned here.
     /// @param Q An EC point in Jacobian coordinates
     function addJacobianMutates(
-    	uint[3] memory P, 
+    	uint[3] memory P,
     	uint[3] memory Q
     ) pure internal {
 
@@ -126,14 +126,14 @@ library Numerology {
 
         zz = mulmod(Qz, Qz, p);
         uint256 a   = mulmod(P[0], zz, p);
-        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p);   
-        
+        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p);
+
 
         if ((a == t0) && (c == t1)){
             doubleMutates(P);
             return;
         }
-        
+
         t1   = addmod(t1, p-c, p); // d = t1 - c
         uint256 b = addmod(t0, p-a, p); // b = t0 - a
         uint256 e = mulmod(b, b, p); // e = b^2
@@ -151,7 +151,7 @@ library Numerology {
     /// @param P An EC point in Jacobian coordinates. The result is returned here.
     /// @param Q An EC point in Jacobian coordinates
     function subJacobianMutates(
-    	uint[3] memory P, 
+    	uint[3] memory P,
     	uint[3] memory Q
     ) pure internal {
         uint256 Pz = P[2];
@@ -173,13 +173,13 @@ library Numerology {
 
         zz = mulmod(Qz, Qz, p);
         uint256 a   = mulmod(P[0], zz, p);
-        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p); 
+        uint256 c   = mulmod(P[1], mulmod(Qz, zz, p), p);
 
         if ((a == t0) && (c == t1)){
             P[2] = 0;
             return;
         }
-        
+
         t1   = addmod(t1, p-c, p); // d = t1 - c
         uint256 b = addmod(t0, p-a, p); // b = t0 - a
         uint256 e = mulmod(b, b, p); // e = b^2
@@ -198,7 +198,7 @@ library Numerology {
     /// @param Q An EC point in affine coordinates
     /// @return R An EC point in Jacobian coordinates with the sum, represented by an array of 3 uint256
     function addAffineJacobian(
-    	uint[2] memory P, 
+    	uint[2] memory P,
     	uint[2] memory Q
     ) internal pure returns (uint[3] memory R) {
 
@@ -222,8 +222,8 @@ library Numerology {
     }
 
     /// @notice Point doubling in Jacobian coordinates
-    /// @param P An EC point in Jacobian coordinates. 
-    /// @return Q An EC point in Jacobian coordinates   
+    /// @param P An EC point in Jacobian coordinates.
+    /// @return Q An EC point in Jacobian coordinates
     function doubleJacobian(uint[3] memory P) internal pure returns (uint[3] memory Q) {
         uint256 z = P[2];
         if (z == 0)
@@ -257,9 +257,9 @@ library Numerology {
         P[1] = addmod(mulmod(m, addmod(s, p - t, p), p), mulmod(0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffff7ffffe17, mulmod(_4yy, _4yy, p), p), p);
         P[2] = mulmod(_2y, z, p);
     }
-    
+
     function _lookup_sim_mul(
-    	uint256[3][4][4] memory iP, 
+    	uint256[3][4][4] memory iP,
     	uint256[4] memory P_Q
     ) internal pure {
         uint256 p = fieldOrder;
@@ -271,7 +271,7 @@ library Numerology {
         // P1 Lookup Table
         iPj = iP[0];
         iPj[0] = [P_Q[0], P_Q[1], 1];  						// P1
-        
+
         double = doubleJacobian(iPj[0]);
         iPj[1] = addJac(double, iPj[0]);
         iPj[2] = addJac(double, iPj[1]);
@@ -306,7 +306,7 @@ library Numerology {
     /// @return ptr : The pointer to the first coefficient
     /// @return length :  the total length of the array
     function _wnaf(int256 d) internal pure returns (uint256 ptr, uint256 length){
-    
+
         int sign = d < 0 ? -1 : int(1);
         uint256 k = uint256(sign * d);
 
@@ -326,30 +326,30 @@ library Numerology {
                 length := add(length, 1)
                 k := div(k, 2)
             }
-            //log3(ptr, 1, 0xfabadaacabada, d, length)    
+            //log3(ptr, 1, 0xfabadaacabada, d, length)
         }
 
         return (ptr, length);
     }
 
-    /// @notice Simultaneous multiplication of the form kP + lQ. 
+    /// @notice Simultaneous multiplication of the form kP + lQ.
     /// @dev Scalars k and l are expected to be decomposed such that k = k1 + k2 λ, and l = l1 + l2 λ,
     /// where λ is specific to the endomorphism of the curve
     /// @param k_l An array with the decomposition of k and l values, i.e., [k1, k2, l1, l2]
     /// @param P_Q An array with the affine coordinates of both P and Q, i.e., [P1, P2, Q1, Q2]
     function _sim_mul(
-    	int256[4] memory k_l, 
+    	int256[4] memory k_l,
     	uint256[4] memory P_Q
     ) internal pure returns (uint[3] memory Q) {
 
     	require(
-    		is_on_curve(P_Q[0], P_Q[1]) && is_on_curve(P_Q[2], P_Q[3]), 
+    		is_on_curve(P_Q[0], P_Q[1]) && is_on_curve(P_Q[2], P_Q[3]),
     		"Invalid points"
     	);
 
         uint256[4] memory wnaf;
         uint256 max_count = 0;
-        uint256 count = 0;        
+        uint256 count = 0;
 
         for(uint j=0; j<4; j++){
             (wnaf[j], count) = _wnaf(k_l[j]);
@@ -361,16 +361,16 @@ library Numerology {
         Q = _sim_mul_wnaf(wnaf, max_count, P_Q);
     }
 
-    
+
     function _sim_mul_wnaf(
-    	uint256[4] memory wnaf_ptr, 
-    	uint256 length, 
+    	uint256[4] memory wnaf_ptr,
+    	uint256 length,
     	uint256[4] memory P_Q
     ) internal pure returns (uint[3] memory Q) {
         uint256[3][4][4] memory iP;
         _lookup_sim_mul(iP, P_Q);
 
-        // LOOP 
+        // LOOP
         uint256 i = length;
         uint256 ki;
         uint256 ptr;
@@ -399,7 +399,7 @@ library Numerology {
                 subJacobianMutates(Q, iP[1][(15 - ki) / 2]);
             } else if (ki > 0) {
                 addJacobianMutates(Q, iP[1][(ki - 1) / 2]);
-            } 
+            }
 
             ptr = wnaf_ptr[2] + i;
             assembly {
@@ -410,7 +410,7 @@ library Numerology {
                 subJacobianMutates(Q, iP[2][(15 - ki) / 2]);
             } else if (ki > 0) {
                 addJacobianMutates(Q, iP[2][(ki - 1) / 2]);
-            } 
+            }
 
             ptr = wnaf_ptr[3] + i;
             assembly {
@@ -421,8 +421,8 @@ library Numerology {
                 subJacobianMutates(Q, iP[3][(15 - ki) / 2]);
             } else if (ki > 0) {
                 addJacobianMutates(Q, iP[3][(ki - 1) / 2]);
-            } 
-            
+            }
+
         }
     }
 
@@ -444,10 +444,10 @@ library Numerology {
 
     // https://ethresear.ch/t/you-can-kinda-abuse-ecrecover-to-do-ecmul-in-secp256k1-today/2384/4
     function ecmulVerify(
-    	uint256 x1, 
-    	uint256 y1, 
-    	uint256 scalar, 
-    	uint256 qx, 
+    	uint256 x1,
+    	uint256 y1,
+    	uint256 scalar,
+    	uint256 qx,
     	uint256 qy
     ) internal pure returns(bool) {
 	    uint256 curve_order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
@@ -462,8 +462,8 @@ library Numerology {
     /// @param _pointY The Y coordinate of an EC point in affine representation
     /// @return true iff _pointSign and _pointX are the compressed representation of (_pointX, _pointY)
 	function check_compressed_point(
-		uint8 _pointSign, 
-		uint256 _pointX, 
+		uint8 _pointSign,
+		uint256 _pointX,
 		uint256 _pointY
 	) internal pure returns(bool) {
 		bool correct_sign = _pointY % 2 == _pointSign - 2;

--- a/tests/WebAuthn_forge/src/Secp256k1.sol
+++ b/tests/WebAuthn_forge/src/Secp256k1.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "src/ECCMath.sol";
 
@@ -271,11 +271,11 @@ library Secp256k1 {
                 i := add(i, 1)
                 continue
 		}
-            
+
 	         dm := mod(d, 32)
                 mstore8(add(dwPtr, i), dm) // Don't store as signed - convert when reading.
                 d := add(sub(d, dm), mul(gt(dm, 16), 32))
-            
+
         }
         }
 

--- a/tests/WebAuthn_forge/src/Secp256r1.sol
+++ b/tests/WebAuthn_forge/src/Secp256r1.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.20;
-// 
-// Heavily inspired from 
+pragma solidity >=0.8.19 <0.9.0;
+//
+// Heavily inspired from
 // https://github.com/maxrobot/elliptic-solidity/blob/master/contracts/Secp256r1.sol
 // https://github.com/tdrerup/elliptic-curve-solidity/blob/master/contracts/curves/EllipticCurve.sol
 // modified to use precompile 0x05 modexp
 // and modified jacobian double
 // optimisations to avoid to an from from affine and jacobian coordinates
-// 
+//
 struct PassKeyId {
     uint256 pubKeyX;
     uint256 pubKeyY;
@@ -25,7 +25,7 @@ library Secp256r1 {
     uint256 constant gx = 0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296;
     uint256 constant gy = 0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5;
     uint256 public constant pp = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF;
-                          
+
     uint256 public constant nn = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551;
     uint256 constant a = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC;
     uint256 constant b = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B;
@@ -147,9 +147,9 @@ library Secp256r1 {
         (x, y, z) = _modifiedJacobianDouble(p.x, p.y, p.z);
         return JPoint(x, y, z);
     }
- 
+
     /* _affineFromJacobian
-    * @desription returns affine coordinates from a jacobian input follows 
+    * @desription returns affine coordinates from a jacobian input follows
     * golang elliptic/crypto library
     */
     function _affineFromJacobian(uint x, uint y, uint z)
@@ -172,7 +172,7 @@ library Secp256r1 {
     * https://hyperelliptic.org/EFD/g1p/auto-code/shortw/jacobian-3/doubling/mdbl-2007-bl.op3
     */
     function _jAdd(uint p1, uint p2, uint p3, uint q1, uint q2, uint q3)
-        internal pure returns(uint r1, uint r2, uint r3)    
+        internal pure returns(uint r1, uint r2, uint r3)
     {
         if (p3 == 0) {
             r1 = q1;
@@ -250,7 +250,7 @@ library Secp256r1 {
 
     // Point doubling on the modified jacobian coordinates
     // http://point-at-infinity.org/ecc/Prime_Curve_Modified_Jacobian_Coordinates.html
-    function _modifiedJacobianDouble(uint x, uint y, uint z) 
+    function _modifiedJacobianDouble(uint x, uint y, uint z)
         internal pure returns (uint x3, uint y3, uint z3)
     {
         assembly {
@@ -299,7 +299,7 @@ library Secp256r1 {
             }
             // Free memory pointer is always stored at 0x40
             let freemem := mload(0x40)
-            
+
             mstore(freemem, 0x20)
             mstore(add(freemem, 0x20), 0x20)
             mstore(add(freemem, 0x40), 0x20)
@@ -313,9 +313,9 @@ library Secp256r1 {
             case 0 {
                 revert(0x0, 0x0)
             } default {
-                ret := mload(freemem) 
+                ret := mload(freemem)
             }
-        }        
+        }
     }
 
 }

--- a/tests/WebAuthn_forge/src/Secp256r1_maxrobot.sol
+++ b/tests/WebAuthn_forge/src/Secp256r1_maxrobot.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 library Secp256r1_maxrobot {
 
     uint256 constant gx = 0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296;
     uint256 constant gy = 0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5;
     uint256 constant pp = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF;
-                          
+
     uint256 constant nn = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551;
     uint256 constant a = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC;
     uint256 constant b = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B;
@@ -46,7 +46,7 @@ library Secp256r1_maxrobot {
     * scalarMultiplications
     * @description - performs a number of EC operations required in te pk signature verification
     */
-    function scalarMultiplications(uint X, uint Y, uint u1, uint u2) 
+    function scalarMultiplications(uint X, uint Y, uint u1, uint u2)
         public pure returns(uint, uint)
     {
         uint x1;
@@ -60,7 +60,7 @@ library Secp256r1_maxrobot {
         return Add(x1, y1, x2, y2);
     }
 
-    function Add(uint p1, uint p2, uint q1, uint q2) 
+    function Add(uint p1, uint p2, uint q1, uint q2)
         public pure returns(uint, uint)
     {
         uint p3;
@@ -69,7 +69,7 @@ library Secp256r1_maxrobot {
         return _affineFromJacobian(p1, p2, p3);
     }
 
-    function Double(uint p1, uint p2) 
+    function Double(uint p1, uint p2)
         public pure returns(uint, uint)
     {
         uint p3;
@@ -77,7 +77,7 @@ library Secp256r1_maxrobot {
 
         return _affineFromJacobian(p1, p2, p3);
     }
- 
+
     /*
     * ScalarMult
     * @description performs scalar multiplication of two elliptic curve points, based on golang
@@ -101,7 +101,7 @@ library Secp256r1_maxrobot {
                 k[i] = k[i] << 1;
             }
         }
-        
+
         return _affineFromJacobian(x, y, z);
         }
     }
@@ -119,7 +119,7 @@ library Secp256r1_maxrobot {
 
 
     /* _affineFromJacobian
-    * @desription returns affine coordinates from a jacobian input follows 
+    * @desription returns affine coordinates from a jacobian input follows
     * golang elliptic/crypto library
     */
     function _affineFromJacobian(uint x, uint y, uint z)
@@ -142,7 +142,7 @@ library Secp256r1_maxrobot {
     * https://hyperelliptic.org/EFD/g1p/auto-code/shortw/jacobian-3/doubling/mdbl-2007-bl.op3
     */
     function _jAdd(uint p1, uint p2, uint p3, uint q1, uint q2, uint q3)
-        public pure returns(uint r1, uint r2, uint r3)    
+        public pure returns(uint r1, uint r2, uint r3)
     {
         if (p3 == 0) {
             r1 = q1;
@@ -228,14 +228,14 @@ library Secp256r1_maxrobot {
     * https://hyperelliptic.org/EFD/g1p/auto-code/shortw/jacobian-3/doubling/dbl-2001-b.op3
     */
     function _jDouble(uint p1, uint p2, uint p3)
-        public pure returns(uint q1, uint q2, uint q3)    
+        public pure returns(uint q1, uint q2, uint q3)
     {
         assembly {
             let pd := 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
             let delta := mulmod(p3, p3, pd) // delta = Z1^2
             let gamma := mulmod(p2, p2, pd) // gamma = Y1^2
             let beta := mulmod(p1, gamma, pd) // beta = X1*gamma
-            
+
             let alpha := p1
             if lt(alpha, delta) {
                 alpha := add(pd, alpha)
@@ -247,10 +247,10 @@ library Secp256r1_maxrobot {
                 q1 := add(pd, q1)
             }
             q1 := sub(q1, mulmod(0x08, beta, pd)) // X3 = (alpha^2)-(8*beta)
-            
+
             q3  := addmod(p2, p3, pd)
             q3 := mulmod(q3, q3, pd)
-            
+
             delta := addmod(delta, gamma, pd)
             if lt(q3, delta) {
                 q3 := add(pd, q3)
@@ -270,7 +270,7 @@ library Secp256r1_maxrobot {
         }
     }
 
-    function _hashToUint(bytes memory input) 
+    function _hashToUint(bytes memory input)
         public pure returns (uint)
     {
         require(input.length >= 32, "slicing out of range");
@@ -292,7 +292,7 @@ library Secp256r1_maxrobot {
 
     /*
     * invmod
-    * @description returns the inverse of an integer 
+    * @description returns the inverse of an integer
     */
     function _invmod(uint value, uint p)
         public pure returns (uint)
@@ -303,13 +303,13 @@ library Secp256r1_maxrobot {
         if (value > p) {
             value = value % p;
         }
-        
+
         int t1;
         int t2 = 1;
         uint r1 = p;
         uint r2 = value;
         uint q;
-        
+
         while (r2 != 0) {
             q = r1 / r2;
             (t1, t2, r1, r2) = (t2, t1 - int(q) * t2, r2, r1 - q * r2);
@@ -318,7 +318,7 @@ library Secp256r1_maxrobot {
         if (t1 < 0) {
             return (p - uint(-t1));
         }
-        
+
         return uint(t1);
       }
     }

--- a/tests/WebAuthn_forge/test/FCL_Webauthn.t.sol
+++ b/tests/WebAuthn_forge/test/FCL_Webauthn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 //FreshCryptoLib implementation
@@ -7,7 +7,7 @@ import "src/FCL_elliptic.sol";
 import "src/FCL_Webauthn.sol";
 
 //orbs_network implementation
-import "src/ECops.sol"; 
+import "src/ECops.sol";
 
 
 
@@ -16,27 +16,27 @@ contract WebAuthn_bench {
      uint256 constant _FCL_ID=0;
      uint256 constant _ORBS_ID=1;
      uint256 constant _ALEMBICH_ID=2;
-     
+
      uint256 constant _MAXID=0;
-    
+
     uint256  corelib_ID;
     uint256  dataPointer;
-    
-    
+
+
     function set_dataPointer(uint256 i_dataPointer) public
     {
      dataPointer=i_dataPointer;
     }
-    
+
     constructor(uint256 libID) {
-     
+
      if(libID>_MAXID){
       revert();
      }
-     
+
      corelib_ID=libID;
-    }   
-}	
+    }
+}
 
 
 

--- a/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
+++ b/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
@@ -14,7 +14,7 @@
 ///* DESCRIPTION: test file for elliptic primitives
 ///*
 //**************************************************************************************/
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 import "../src/FCL_elliptic.sol";
@@ -48,7 +48,7 @@ contract ArithmeticTest is Test {
     uint256 constant _prec_address = 0xcaca;
     uint256 constant _NUM_TEST_ECMULMULADD=100;
     uint256 constant _NUM_TEST_DBL=100;
- 
+
     function test_Fuzz_InVmodn(uint256 i_u256_a) public {
         vm.assume(i_u256_a < FCL_Elliptic_ZZ.n);
         vm.assume(i_u256_a != 0);
@@ -67,8 +67,8 @@ contract ArithmeticTest is Test {
         assertEq(mulmod(res, i_u256_a, FCL_Elliptic_ZZ.p), 1);
     }
     //ecAff_isOnCurve
-   
-   
+
+
     //check consistency of ecmulmuladd and Add
     function test_invariant_FCL_Ecmulmuladd() public {
         uint256 ecpoint_Rx=0;
@@ -77,14 +77,14 @@ contract ArithmeticTest is Test {
         uint256 ecpoint_Rzzz=1;
        uint256  checkpointGasLeft ;
 	uint256  checkpointGasLeft2 ;
-	
+
         //Uncomment the library to test/bench here
         //(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz, ecpoint_Rzzz )= FCL_Elliptic_ZZ.ecZZ_Dbl(gx, gy,1,1);
         (ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz )= ECops.twiceProj(gx, gy,1);
-        
-        
+
+
         checkpointGasLeft=gasleft() ;
-   
+
         for(uint256 i=3;i<=_NUM_TEST_ECMULMULADD;i++){
           // (ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz, ecpoint_Rzzz )= FCL_Elliptic_ZZ.ecZZ_AddN(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz, ecpoint_Rzzz , gx, gy);
 
@@ -95,24 +95,24 @@ contract ArithmeticTest is Test {
 
 //        (ecpoint_Rx, ecpoint_Ry)=FCL_Elliptic_ZZ.ecZZ_SetAff(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz, ecpoint_Rzzz);
         (ecpoint_Rx, ecpoint_Ry)=ECops.toAffinePoint(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz);
-        
+
         //generate a small multiple of G using scalar
         assertEq(ecpoint_Rx, FCL_Elliptic_ZZ.ecZZ_mulmuladd_S_asm(0,0, _NUM_TEST_ECMULMULADD, 0));
-        
+
           checkpointGasLeft=gasleft() ;
         for(uint256 i=3;i<=_NUM_TEST_DBL;i++){
            //(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz, ecpoint_Rzzz )=FCL_Elliptic_ZZ.ecZZ_Dbl(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz, ecpoint_Rzzz );
-           
+
               (ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz )= ECops.twiceProj(ecpoint_Rx, ecpoint_Ry,ecpoint_Rzz);
-     
+
         }
           checkpointGasLeft2=gasleft() ;
         console.log("Dbl number test and gas cost :", _NUM_TEST_ECMULMULADD, checkpointGasLeft - checkpointGasLeft2 - 100);
 
 
     }
-    
-    
-    
-}    
-    
+
+
+
+}
+

--- a/tests/WebAuthn_forge/test/bench_androlo.t.sol
+++ b/tests/WebAuthn_forge/test/bench_androlo.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 
 import "forge-std/Test.sol";
@@ -28,12 +28,12 @@ contract test_Androlo is Test {
         if (!Secp256k1.isPubKey(Q))
             return false;
 
-     
+
         uint sInv = ECCMath.invmod(rs[1], n);
 
         uint[3] memory u1G = Secp256k1._mul(mulmod(e, sInv, n), [Gx, Gy]);
-        
-     
+
+
         uint[3] memory u2Q = Secp256k1._mul(mulmod(rs[0], sInv, n), Q);
         uint[3] memory P = Secp256k1._add(u1G, u2Q);
 
@@ -62,6 +62,6 @@ contract test_Androlo is Test {
 
     return res;
    }
-   
-   
+
+
 }

--- a/tests/WebAuthn_forge/test/bench_numerology.t.sol
+++ b/tests/WebAuthn_forge/test/bench_numerology.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 
 import "forge-std/Test.sol";
@@ -6,13 +6,13 @@ import "../src/Numerology.sol";
 
 contract test_Numerology is Test {
 
-    
+
   function test_proof_verification() public view returns (bool) {
     // Verifier.deployed().then(function(inst) { return inst.test_proof_verification.estimateGas(); })
 
-    int256[4] memory k_l = [int256(-89243190524605339210527649141408088119), 
+    int256[4] memory k_l = [int256(-89243190524605339210527649141408088119),
                             int256(-53877858828609620138203152946894934485),
-                            int256(-185204247857117235934281322466442848518), 
+                            int256(-185204247857117235934281322466442848518),
                             int256(-7585701889390054782280085152653861472)];
 
     uint256[4] memory P_Q = [0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
@@ -21,25 +21,25 @@ contract test_Numerology is Test {
                              0x1ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a];
     uint256  checkpointGasLeft ;
     uint256  checkpointGasLeft2 ;
-	
+
     uint256[4] memory wnaf;
     uint256 max_count = 0;
-    uint256 count = 0;        
+    uint256 count = 0;
     checkpointGasLeft=gasleft() ;
-          
+
     for(uint j=0; j<4; j++){
         (wnaf[j], count) = Numerology._wnaf(k_l[j]);
         if(count > max_count){
           max_count = count;
         }
     }
-    
+
     uint256[3] memory kP_lQ = Numerology._sim_mul_wnaf(wnaf, max_count, P_Q);
     checkpointGasLeft2=gasleft() ;
     console.log("Numerology Sec256k1 ecmulmuladd:", checkpointGasLeft - checkpointGasLeft2 - 100);
 
     uint256[3] memory expected = [0x7635e27fba8e1f779dcfdde1b1eacbe0571fbe39ecf6056d29ba4bd3ef5e22f2,
-                                  0x197888e5cec769ac2f1eb65dbcbc0e49c00a8cdf01f8030d8286b68c1933fb18, 
+                                  0x197888e5cec769ac2f1eb65dbcbc0e49c00a8cdf01f8030d8286b68c1933fb18,
                                   1];
 
     return Numerology.eqJacobian(kP_lQ, expected);
@@ -56,8 +56,8 @@ contract test_Numerology is Test {
                              0xdf67fd3f4255826c234a5262adc70e14a6d42f13ee55b65e885e666e1dd5d3f5,
                              0x3f75f99c8df97f477b700407dd7a956cee2e4915f2df4fa9b11c403935c05dc5,
                              0x497495d2e486fd4cff4929265eac91711014b9d6ad1c2220d709e20d466627fd];
-    
-    
+
+
     uint256[6] memory expected = [0xaddcb45773b26a2f8ac2143627d54f47a12aab533dc1b41b4e791985e9eca496, // kP_x
                                   0x72da5adb3a30a2cf147d309b0cf58c76b322c82a5edae164e13dbeed6429c41d, // kP_y
                                   0xf07716879380e987f8b5551a1d989068d0003061088a869a33ceb9848771c6fd, // lQ_x
@@ -81,7 +81,7 @@ contract test_Numerology is Test {
     uint256 e3 = 0x2447ed4564b75b0f9ff84013aaa37c2ab67a2c621b0edc91a06895f19a93aebb; // lQ_y
     uint256 e4 = 0x9ca8f6ff6a2eb6f62787f70b9f7c4939d1a3890ec87343e4f6716f9f6867eb86; // Rx
     uint256 e5 = 0x290c40f22995dc8b956d2c63ec060d332d082124d638ed618891171db8bc206f; // Ry
-                                  
+
     return Numerology.eqAffineJacobian([e4, e5], Numerology.addAffineJacobian([e0, e1], [e2, e3]));
   }
 }


### PR DESCRIPTION
Right now, not all EVM-networks support the version 0.8.20 due to the `PUSH0` opcode. By making the libraries compilable using the version 0.8.19, they are more portable.