### PR TITLE
Reduced gas cost

### DIFF
--- a/solidity/tests/WebAuthn_hardhat/contracts/Webauthn.sol
+++ b/solidity/tests/WebAuthn_hardhat/contracts/Webauthn.sol
@@ -19,13 +19,17 @@ contract Webauthn {
     function ecdsa_verif( bytes32 hash,  uint[2] calldata rs,
         uint[2] calldata Q)  public  returns (bool)
     {
-    // bytes32 message = sha256(verifyData);
-     console.log("hash=", uint(hash));
-    console.log("rs0=", rs[0]);
-    
-     bool result=FCL_Elliptic_ZZ.ecdsa_verify(bytes32(hash), rs, Q);
-     console.log("result= %s", result);
-
+        // bytes32 message = sha256(verifyData);
+        console.log("hash=", uint(hash));
+        console.log("rs0=", rs[0]);
+        uint256 gasleft1 = gasleft();
+        bool result=FCL_Elliptic_ZZ.ecdsa_verify(bytes32(hash), rs, Q);
+        uint256 gasleft2 = gasleft();
+        uint256 gasused = gasleft1 - gasleft2;
+        if(result){
+            console.log("gasused=%s", gasused);
+        }
+        console.log("result= %s", result);
     }
     
 


### PR DESCRIPTION
With the code equivalent, executing ecZZ_mulmuladd_S_asm reduced gas cost by <u>811 gas</u>:

|        | Gas        |
| ------ | ---------- |
| Before | 208444 gas |
| After  | 207633 gas |

- Testing step:

  1. Open the file: /solidity/tests/WebAuthn_hardhat/test/Webauthn.js

  2. Uncomment line 80: let keyPair = ec.keyFromPrivate( "97ddae0f3a25b92268175400149d65d6887b9cefaf28ea2c078e05cdc15a3c01");

  3. Comment lines 82-83.

  4. `npx hardhat test | grep gasused`

     The purpose of using a fixed key is to perform gas tests with deterministic data.