### PR TITLE
Reduced gas cost ( -3167gas )

### DIFF
--- a/solidity/tests/WebAuthn_hardhat/contracts/FCL_Webauthn.sol
+++ b/solidity/tests/WebAuthn_hardhat/contracts/FCL_Webauthn.sol
@@ -101,12 +101,13 @@ library FCL_WebAuthn {
         uint[2] calldata rs,
         uint[2] calldata Q
     ) internal  returns (bool) {
-    	 // Let the caller check if User Presence (0x01) or User Verification (0x04) are set
-      
-       bytes32 message= FCL_WebAuthn.WebAuthn_format(authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs);
-       
-	bool result=FCL_Elliptic_ZZ.ecdsa_verify(message, rs, Q);
-	
+        // Let the caller check if User Presence (0x01) or User Verification (0x04) are set
+        bytes32 message= FCL_WebAuthn.WebAuthn_format(authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs);
+        uint256 r = rs[0];
+        uint256 s = rs[1];
+        uint256 Qx = Q[0];
+        uint256 Qy = Q[1];
+        bool result=FCL_Elliptic_ZZ.ecdsa_verify(message, r, s, Qx, Qy);
         return result;
     }
     
@@ -126,7 +127,7 @@ library FCL_WebAuthn {
        
        console.log("input to prec:",uint256(message));
        
-	bool result=FCL_Elliptic_ZZ.ecdsa_precomputed_verify(message, rs,  dataPointer);
+	bool result=FCL_Elliptic_ZZ.ecdsa_precomputed_verify(message, rs[0], rs[1],  dataPointer);
 	
 
         return result;
@@ -148,7 +149,7 @@ library FCL_WebAuthn {
        bytes32 message= FCL_WebAuthn.WebAuthn_format(authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs);
        
        
-	bool result=FCL_Elliptic_ZZ.ecdsa_precomputed_hackmem(message, rs,  dataPointer);
+	bool result=FCL_Elliptic_ZZ.ecdsa_precomputed_hackmem(message, rs[0], rs[1],  dataPointer);
 	
 
         return result;

--- a/solidity/tests/WebAuthn_hardhat/contracts/Webauthn.sol
+++ b/solidity/tests/WebAuthn_hardhat/contracts/Webauthn.sol
@@ -22,8 +22,12 @@ contract Webauthn {
         // bytes32 message = sha256(verifyData);
         console.log("hash=", uint(hash));
         console.log("rs0=", rs[0]);
+        uint256 r = rs[0];
+        uint256 s = rs[1];
+        uint256 Qx = Q[0];
+        uint256 Qy = Q[1];
         uint256 gasleft1 = gasleft();
-        bool result=FCL_Elliptic_ZZ.ecdsa_verify(bytes32(hash), rs, Q);
+        bool result=FCL_Elliptic_ZZ.ecdsa_verify(bytes32(hash), r, s, Qx, Qy);
         uint256 gasleft2 = gasleft();
         uint256 gasused = gasleft1 - gasleft2;
         if(result){

--- a/solidity/tests/WebAuthn_hardhat/contracts/Webauthn_prec.sol
+++ b/solidity/tests/WebAuthn_hardhat/contracts/Webauthn_prec.sol
@@ -107,7 +107,7 @@ contract Webauthn_prec3{
    //  console.log("hash=", uint(hash));
    // console.log("rs0=", rs[0]);
     
-     bool result=FCL_Elliptic_ZZ.ecdsa_precomputed_verify(bytes32(hash), rs, dataPointer);
+     bool result=FCL_Elliptic_ZZ.ecdsa_precomputed_verify(bytes32(hash), rs[0], rs[1], dataPointer);
     // console.log("result= %s", result);
 
     }


### PR DESCRIPTION
With the code equivalent, executing ecZZ_mulmuladd_S_asm reduced gas cost by <u>3167 gas</u>:

|        | Gas        |
| ------ | ---------- |
| Before | 207633 gas |
| After  | 204466 gas |

- Testing step:

  1. Open the file: /solidity/tests/WebAuthn_hardhat/test/Webauthn.js

  2. Uncomment line 80: let keyPair = ec.keyFromPrivate( "97ddae0f3a25b92268175400149d65d6887b9cefaf28ea2c078e05cdc15a3c01");

  3. Comment lines 82-83.

  4. `npx hardhat test | grep gasused`

     The purpose of using a fixed key is to perform gas tests with deterministic data.

list:
1. ```(uint[2] calldata rs,uint[2] calldata Q) -> (uint256 r,uint256 s,uint256 Qx,uint256 Qy)  ``` save 393 gas

2. ```if (rs[0] == 0 || rs[0] >= n || rs[1] == 0||rs[1]>=n) -> iszero(mul(mul(r, s), and(gt(n, r), gt(n, s)))) ``` save 118 gas

3. Update `ecAff_isOnCurve` save 176 gas

4. ```uint[6] memory -> let pointer := mload(0x40)```  save 135 gas

5. ```if eq(y2,0) -> if iszero(y2)``` save 1170 gas

   ... and more