### PR TITLE
Multiple SPDX removal for flattening bug+ harmonization of solc versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ The implemented content is:
 
 
 ### Directory solidity:
-* FCL_elliptic.sol: an EVM optimized implementation of sec256r1(P256), using language hacks and specificities, as described in paper https://eprint.iacr.org/2023/939.pdf.
+
+* FCL_ecdsa.sol: an EVM optimized implementation of ecdsa over sec256r1(P256), using language hacks and specificities, as described in paper https://eprint.iacr.org/2023/939.pdf.
 * FCL_eddsa.sol   : an EVM optimized implementation of ed25519, using same paper tricks.
 * FCL_sha512.sol : implementation of the SHA512 primitive (single bloc implementation)
 * FLC_Webauthn.sol: implementation of the WebAuthn2/FIDO2 authentication over ECDSA with P256
 <!--- FCL_ecdaa.sol: an EVM version of the ECDAA anonymous attestation for anonymous airdrops -->
 
 ### Directory cairo0.9:
+
 * FCL_ec_mulmuladd.cairo: an implementation of the operation aP+bQ (addition of the results of two distincts point multiplication by scalar a and b). It uses the Shamir's trick with the windowing method.
 signature_opt.cairo : optimisation of ECDSA verification using ec_mulmuladd_W function
 

--- a/solidity/external/ECCMath.sol
+++ b/solidity/external/ECCMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 /**
  * @title ECCMath

--- a/solidity/external/ECops.sol
+++ b/solidity/external/ECops.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 // Orbs implementation
 library ECops {

--- a/solidity/external/Numerology.sol
+++ b/solidity/external/Numerology.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 /// @title Numerology: A Solidity library for fast ECC arithmetics using curve secp256k1
 /// @author David Nuñez (david@nucypher.com)

--- a/solidity/external/Secp256k1.sol
+++ b/solidity/external/Secp256k1.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "./ECCMath.sol";
 

--- a/solidity/external/Secp256r1.sol
+++ b/solidity/external/Secp256r1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 //
 // Heavily inspired from
 // https://github.com/maxrobot/elliptic-solidity/blob/master/contracts/Secp256r1.sol

--- a/solidity/external/Secp256r1_maxrobot.sol
+++ b/solidity/external/Secp256r1_maxrobot.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 library Secp256r1_maxrobot {
     uint256 constant gx = 0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296;

--- a/solidity/src/FCL_Webauthn.sol
+++ b/solidity/src/FCL_Webauthn.sol
@@ -17,8 +17,8 @@
 //* WARNING: this code SHALL not be used for non prime order curves for security reasons.
 // Code is optimized for a=-3 only curves with prime order, constant like -1, -2 shall be replaced
 // if ever used for other curve than sec256R1
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
+pragma solidity >=0.8.19 <0.9.0;
 
 import {Base64Url} from "./utils/Base64Url.sol";
 import {FCL_Elliptic_ZZ} from "./FCL_elliptic.sol";

--- a/solidity/src/FCL_ecdsa.sol
+++ b/solidity/src/FCL_ecdsa.sol
@@ -18,8 +18,8 @@
 //* WARNING: this code SHALL not be used for non prime order curves for security reasons.
 // Code is optimized for a=-3 only curves with prime order, constant like -1, -2 shall be replaced
 // if ever used for other curve than sec256R1
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
+pragma solidity >=0.8.19 <0.9.0;
 
 
 import {FCL_Elliptic_ZZ} from "./FCL_elliptic.sol";

--- a/solidity/src/FCL_ed25519.sol
+++ b/solidity/src/FCL_ed25519.sol
@@ -15,7 +15,7 @@
 ///*  optimization
 ///*
 //**************************************************************************************/
-// SPDX-License-Identifier: MIT
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
 pragma solidity >=0.8.19 <0.9.0;
 
 // prime field modulus of the ed25519 curve

--- a/solidity/src/FCL_eddsa.sol
+++ b/solidity/src/FCL_eddsa.sol
@@ -14,7 +14,7 @@
 ///* DESCRIPTION: Implementation of RFC8032 using FCL Shamir's trick
 ///*
 //**************************************************************************************/
-// SPDX-License-Identifier: MIT
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
 pragma solidity >=0.8.19 <0.9.0;
 
 //import "./FCL_ed25519.sol" as Curve;

--- a/solidity/src/FCL_edwards.sol
+++ b/solidity/src/FCL_edwards.sol
@@ -14,7 +14,7 @@
 ///* DESCRIPTION: Implementation of RFC8032 using FCL Shamir's trick
 ///*
 //**************************************************************************************/
-// SPDX-License-Identifier: MIT
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
 pragma solidity >=0.8.19 <0.9.0;
 
 import "./FCL_ed25519.sol" as Curve;

--- a/solidity/src/FCL_elliptic.sol
+++ b/solidity/src/FCL_elliptic.sol
@@ -18,8 +18,8 @@
 //* WARNING: this code SHALL not be used for non prime order curves for security reasons.
 // Code is optimized for a=-3 only curves with prime order, constant like -1, -2 shall be replaced
 // if ever used for other curve than sec256R1
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
+pragma solidity >=0.8.19 <0.9.0;
 
 library FCL_Elliptic_ZZ {
     // Set parameters for curve sec256r1.

--- a/solidity/src/FCL_sha512.sol
+++ b/solidity/src/FCL_sha512.sol
@@ -16,8 +16,8 @@
 //**************************************************************************************/
 //Initialize hash values:
 //(first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
-
-pragma solidity ^0.8.20;
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
+pragma solidity >=0.8.19 <0.9.0;
 
 library sha512 {
     uint256 constant SHA512_BLOCK_LENGTH8 = 128;

--- a/solidity/src/fcl_ecdsa_precbytecode.sol
+++ b/solidity/src/fcl_ecdsa_precbytecode.sol
@@ -1,3 +1,4 @@
+pragma solidity >=0.8.19 <0.9.0;
 // Public key
 //x:fdf8bce27f54e06f3aee3b6a542db1ab1f2418d7370a78b150d06965f942b14a y:470cdee69ab50e610c39b840681bf816b030f4a0a5d5af02ce27dcce6bede89f
 bytes constant x =

--- a/solidity/tests/WebAuthn_forge/foundry.toml
+++ b/solidity/tests/WebAuthn_forge/foundry.toml
@@ -2,6 +2,8 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc = "0.8.19"
+
 optimizer = true
 optimizer_runs = 1000000
 allow_paths = ["../../../solidity"]

--- a/solidity/tests/WebAuthn_forge/makefile
+++ b/solidity/tests/WebAuthn_forge/makefile
@@ -97,3 +97,23 @@ lint-write: forge-lint
 clean: forge-clean
 
 install: git-submodule-update
+
+#  ℹ️ RUN THIS SCRIPT USING A LEDGER:
+#    forge script DeployElliptic.s.sol:MyScript --rpc-url <RPC_URL> --ledger --sender <ACCOUNT_ADDRESS> \
+#    [--broadcast]
+
+#    ℹ️ RUN THIS SCRIPT WITH AN ARBITRARY PRIVATE KEY (NOT RECOMMENDED):
+#    PRIVATE_KEY=<PRIVATE_KEY> forge script DeployElliptic.s.sol:MyScript --rpc-url <RPC_URL> [--broadcast]
+https://ethereum-holesky.publicnode.com
+
+#deploy: forge script DeployElliptic.s.sol:MyScript --rpc-url https://ethereum-sepolia.blockpi.network/v1/rpc/public --private-key b3619b5eb554ae89e6c53ca7d4d1c4dee671a96d16c0a20e597e194609cc2cc2
+deploy:
+	forge script script/DeployElliptic.s.sol:MyScript --rpc-url https://ethereum-sepolia.blockpi.network/v1/rpc/public --private-key b3619b5eb554ae89e6c53ca7d4d1c4dee671a96d16c0a20e597e194609cc2cc2 --etherscan-api-key HURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5X --verify 
+
+#verify: forge verify-contract --rpc-url https://ethereum-holesky.publicnode.com --etherscan-api-key HURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5XHURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5X 0x1695C55D8bFd9C9035a9197191448381e38d1bF9 DeployElliptic.s.sol:LibraryWrapper 
+
+
+#forge verify-contract --etherscan-api-key HURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5XHURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5X --chain holesky --force  0x1695C55D8bFd9C9035a9197191448381e38d1bF9 DeployElliptic.s.sol:LibraryWrapper 
+forge verify-contract --etherscan-api-key HURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5XHURV4UYJZCCUTXEYM73M6J6CIJE1KN1W5X --chain sepolia --flatten --force  0x3c548295a71383976318819599937fC3daC75289 script/DeployElliptic.s.sol:LibraryWrapper --watch
+
+

--- a/solidity/tests/WebAuthn_forge/script/BaseScript.sol
+++ b/solidity/tests/WebAuthn_forge/script/BaseScript.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// License:MIT, SPDX Identifier is removed because it breaks with the flatten command.
 pragma solidity >=0.8.19 <0.9.0;
 
 import {Script} from "../lib/forge-std/src/Script.sol";

--- a/solidity/tests/WebAuthn_forge/test/FCL_Webauthn.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_Webauthn.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 //FreshCryptoLib implementation

--- a/solidity/tests/WebAuthn_forge/test/FCL_Webauthn_Base64Url.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_Webauthn_Base64Url.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.19 <0.9.0;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {FCL_WebAuthn} from "@solidity/FCL_Webauthn.sol";

--- a/solidity/tests/WebAuthn_forge/test/FCL_ecdsa.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_ecdsa.t.sol
@@ -15,7 +15,7 @@
 ///*
 //**************************************************************************************/
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 import "@solidity/FCL_elliptic.sol";

--- a/solidity/tests/WebAuthn_forge/test/FCL_eddsa.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_eddsa.t.sol
@@ -15,7 +15,7 @@
 ///*
 //**************************************************************************************/
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 

--- a/solidity/tests/WebAuthn_forge/test/FCL_edwards.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_edwards.t.sol
@@ -15,7 +15,7 @@
 ///*
 //**************************************************************************************/
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 

--- a/solidity/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
@@ -14,7 +14,7 @@
 ///* DESCRIPTION: test file for elliptic primitives
 ///*
 //**************************************************************************************/
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 import "@solidity/FCL_elliptic.sol";

--- a/solidity/tests/WebAuthn_forge/test/FCL_sha512.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_sha512.t.sol
@@ -15,7 +15,7 @@
 ///*
 //**************************************************************************************/
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 import "@solidity/FCL_sha512.sol";

--- a/solidity/tests/WebAuthn_forge/test/bench_androlo.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/bench_androlo.t.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.8.20;
+
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 

--- a/solidity/tests/WebAuthn_forge/test/bench_androlo.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/bench_androlo.t.sol
@@ -1,4 +1,3 @@
-
 pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";

--- a/solidity/tests/WebAuthn_forge/test/bench_numerology.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/bench_numerology.t.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.8.20;
+
+pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";
 import "@external/Numerology.sol";

--- a/solidity/tests/WebAuthn_forge/test/bench_numerology.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/bench_numerology.t.sol
@@ -1,4 +1,3 @@
-
 pragma solidity >=0.8.19 <0.9.0;
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
having a SPDX license makes the command --flatten for verification fail.

Only one is kept in the wrapper.