### PR TITLE
Accept elementary types for Q

### DIFF
--- a/solidity/src/FCL_Webauthn.sol
+++ b/solidity/src/FCL_Webauthn.sol
@@ -93,13 +93,26 @@ library FCL_WebAuthn {
         uint256[2] calldata rs,
         uint256[2] calldata Q
     ) internal view returns (bool) {
+        return checkSignature(authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs, Q[0], Q[1]);
+    }
+
+    function  checkSignature (
+        bytes calldata authenticatorData,
+        bytes1 authenticatorDataFlagMask,
+        bytes calldata clientData,
+        bytes32 clientChallenge,
+        uint256 clientChallengeDataOffset,
+        uint256[2] calldata rs,
+        uint256 Qx,
+        uint256 Qy
+    ) internal view returns (bool) {
         // Let the caller check if User Presence (0x01) or User Verification (0x04) are set
 
         bytes32 message = FCL_WebAuthn.WebAuthn_format(
             authenticatorData, authenticatorDataFlagMask, clientData, clientChallenge, clientChallengeDataOffset, rs
         );
 
-        bool result = FCL_ecdsa_utils.ecdsa_verify(message, rs, Q);
+        bool result = FCL_ecdsa_utils.ecdsa_verify(message, rs, Qx, Qy);
 
         return result;
     }

--- a/solidity/src/FCL_ecdsa_utils.sol
+++ b/solidity/src/FCL_ecdsa_utils.sol
@@ -35,14 +35,12 @@ library FCL_ecdsa_utils {
      * @dev ECDSA verification, given , signature, and public key.
      */
 
-    function ecdsa_verify(bytes32 message, uint256[2] calldata rs, uint256[2] calldata Q) internal view returns (bool) {
+    function ecdsa_verify(bytes32 message, uint256[2] calldata rs, uint256 Qx, uint256 Qy) internal view returns (bool) {
         uint256 r = rs[0];
         uint256 s = rs[1];
         if (r == 0 || r >= FCL_Elliptic_ZZ.n || s == 0 || s >= FCL_Elliptic_ZZ.n) {
             return false;
         }
-        uint256 Qx = Q[0];
-        uint256 Qy = Q[1];
         if (!FCL_Elliptic_ZZ.ecAff_isOnCurve(Qx, Qy)) {
             return false;
         }
@@ -58,6 +56,10 @@ library FCL_ecdsa_utils {
         
        
         return x1 == 0;
+    }
+
+    function ecdsa_verify(bytes32 message, uint256[2] calldata rs, uint256[2] calldata Q) internal view returns (bool) {
+        return ecdsa_verify(message, rs, Q[0], Q[1]);
     }
 
     function ec_recover_r1(uint256 h, uint256 v, uint256 r, uint256 s) internal view returns (address)

--- a/solidity/tests/WebAuthn_forge/script/DeployElliptic.s.sol
+++ b/solidity/tests/WebAuthn_forge/script/DeployElliptic.s.sol
@@ -86,14 +86,14 @@ contract FCL_all_wrapper {
 contract MyScript is BaseScript {
     function run() external broadcast returns (address addressOfLibrary) {
         // deploy the library contract and return the address
-        addressOfLibrary = address(new FCL_ecdsa_wrapper{salt:0}());
+        addressOfLibrary = address(new FCL_ecdsa_wrapper{salt: 0}());
     }
 }
 
 contract Script_Deploy_FCL_all is BaseScript {
     function run() external broadcast returns (address addressOfLibrary) {
         // deploy the library contract and return the address
-        addressOfLibrary = address(new FCL_all_wrapper{salt:0}());
+        addressOfLibrary = address(new FCL_all_wrapper{salt: 0}());
     }
 }
 


### PR DESCRIPTION
Currently, the public key is accepted as a fixed-size array in the webauthn/ecdsa functions. This is a concern for https://github.com/rdubois-crypto/FreshCryptoLib/issues/9

When using EIP-1271, you can slice all the variables and pass them as call data, except for the public key (Q), which most likely exists as a state variable of some form in the signer contract.

A very naive POC implementation would look like:
```
    function isValidSignature(
        bytes memory _hash,
        bytes calldata _signature
    ) public view returns (bytes4) {
        uint256 authenticatorDataSize = uint256(bytes32(_signature[0:32]));
        bytes calldata authenticatorData = _signature[32:32 +
            authenticatorDataSize];
        uint256 clientDataSize = uint256(
            bytes32(
                _signature[32 + authenticatorDataSize:64 +
                    authenticatorDataSize]
            )
        );
        bytes calldata clientData = _signature[64 + authenticatorDataSize:64 +
            authenticatorDataSize +
            clientDataSize];
        uint256 challengeOffset = uint256(
            bytes32(
                _signature[64 + authenticatorDataSize + clientDataSize:96 +
                    authenticatorDataSize +
                    clientDataSize]
            )
        );
        uint256[2] calldata rs = [
            uint256(
                bytes32(
                    _signature[96 + authenticatorDataSize + clientDataSize:128 +
                        authenticatorDataSize +
                        clientDataSize]
                )
            ),
            uint256(
                bytes32(
                    _signature[128 +
                        authenticatorDataSize +
                        clientDataSize:160 +
                        authenticatorDataSize +
                        clientDataSize]
                )
            )
            ....
```
(will be open sourced if this PR gets accepted)

[Exisiting](https://github.com/cometh-game/p256-signer/blob/68e8abbbf8f041cd1bdb3892e1691e42acdd082f/contracts/FCL/WrapperFCLWebAuthn.sol) workarounds include creating a wrapper library with an external function which is inefficient.

This PR adds new functions in a backwards-compatible manner that accept Q as two elementary uint256 variables.

The original idea comes from @nlordell, many thanks to him :)