### PR TITLE
Optimize Skipping of 0-bits In mulmuladd

### DIFF
--- a/solidity/src/FCL_elliptic.sol
+++ b/solidity/src/FCL_elliptic.sol
@@ -366,11 +366,10 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
 
             }
             assembly {
-                for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
+                for { zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } iszero(zz) {
                     index := sub(index, 1)
-                    T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
+                    zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
                 } {}
-                zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
 
                 if eq(zz, 1) {
                     X := gx
@@ -522,11 +521,10 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
             (H[0], H[1]) = ecAff_add(gx, gy, Q0, Q1); //will not work if Q=P, obvious forbidden private key
 
             assembly {
-                for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
+                for { zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } iszero(zz) {
                     index := sub(index, 1)
-                    T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
+                    zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
                 } {}
-                zz := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
 
                 if eq(zz, 1) {
                     X := gx


### PR DESCRIPTION
When investigating the `mulmuladd` issue, I noticed that at the start of the function, we have a loop to skip `index` for leading 0s in both `u` and `v`.

Currently, it was computing the a value `0bXY` (where `X` bit being set indicates that `v{index}` is set, and `Y` bit indicates that `u{index}` is set) and storing it to a temporary variable (`T4`) for checking if the leading bit was 0 or not. This PR changes the logic to store it directly to the `zz` variable instead of having it be recomputed after the loop finishes.

At first, this was implemented by changing the condition of the loop to "is either `v{index}` or `u{index}` set?" but computing `zz` directly should be slightly better on average (if we assume even bit distribution, there is only a 25% chance this will save gas).

Also, `eq(X, 0) -> iszero(X)` for slightly smaller code and less gas used.

What is the best way to benchmark the difference?