### PR TITLE
Tag All Assembly Blocks as Memory-Safe

### DIFF
--- a/solidity/src/FCL_Webauthn.sol
+++ b/solidity/src/FCL_Webauthn.sol
@@ -51,7 +51,7 @@ library FCL_WebAuthn {
             bytes(challengeEncoded).length
         );
 
-            assembly {
+            assembly ("memory-safe") {
                 calldatacopy(
                     add(challengeExtracted, 32),
                     add(clientData.offset, clientChallengeDataOffset),
@@ -60,7 +60,7 @@ library FCL_WebAuthn {
             }
 
             bytes32 moreData; //=keccak256(abi.encodePacked(challengeExtracted));
-            assembly {
+            assembly ("memory-safe") {
                 moreData := keccak256(add(challengeExtracted, 32), mload(challengeExtracted))
             }
 
@@ -72,12 +72,12 @@ library FCL_WebAuthn {
         // Verify the signature over sha256(authenticatorData || sha256(clientData))
         bytes memory verifyData = new bytes(authenticatorData.length + 32);
 
-        assembly {
+        assembly ("memory-safe") {
             calldatacopy(add(verifyData, 32), authenticatorData.offset, authenticatorData.length)
         }
 
         bytes32 more = sha256(clientData);
-        assembly {
+        assembly ("memory-safe") {
             mstore(add(verifyData, add(authenticatorData.length, 32)), more)
         }
 

--- a/solidity/src/FCL_edwards.sol
+++ b/solidity/src/FCL_edwards.sol
@@ -77,7 +77,7 @@ library Edwards {
         returns (uint256 x3, uint256 y3, uint256 z3, uint256 t3)
     {
         unchecked {
-            assembly {
+            assembly ("memory-safe") {
                 x3 := addmod(y1, sub(p, x1), p) //   = (Y1-X1)
                 t3 := addmod(y2, sub(p, x2), p) //     (Y2-X2)
 
@@ -106,7 +106,7 @@ library Edwards {
         returns (uint256 x3, uint256 y3, uint256 z3, uint256 t3)
     {
         unchecked {
-            assembly {
+            assembly ("memory-safe") {
                 x3 := addmod(y1, sub(p, x1), p) //   = (Y1-X1)
                 t3 := addmod(y2, sub(p, x2), p) //     (Y2-X2)
 
@@ -135,7 +135,7 @@ library Edwards {
         returns (uint256 x3, uint256 y3, uint256 z3, uint256 t3)
     {
         unchecked {
-            assembly {
+            assembly ("memory-safe") {
                 x3 := mulmod(x1, x1, p) //A = X1^2
                 t3 := mulmod(y1, y1, p) //B = Y1^2
                 let P6 := addmod(x3, t3, p) //H=B+A
@@ -186,7 +186,7 @@ library Edwards {
 
             (T[0], T[1]) = ed_AddAff(gx, gy, Q0, Q1);
 
-            assembly {
+            assembly ("memory-safe") {
                 for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
                     index := sub(index, 1)
                     T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))

--- a/solidity/src/FCL_elliptic.sol
+++ b/solidity/src/FCL_elliptic.sol
@@ -53,7 +53,7 @@ library FCL_Elliptic_ZZ {
      * /* inversion mod n via a^(n-2), use of precompiled using little Fermat theorem
      */
     function FCL_nModInv(uint256 u) internal view returns (uint256 result) {
-        assembly {
+        assembly ("memory-safe") {
             let pointer := mload(0x40)
             // Define length of base, exponent and modulus. 0x20 == 32 bytes
             mstore(pointer, 0x20)
@@ -74,7 +74,7 @@ library FCL_Elliptic_ZZ {
      */
 
     function FCL_pModInv(uint256 u) internal view returns (uint256 result) {
-        assembly {
+        assembly ("memory-safe") {
             let pointer := mload(0x40)
             // Define length of base, exponent and modulus. 0x20 == 32 bytes
             mstore(pointer, 0x20)
@@ -224,7 +224,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
         returns (uint256 P0, uint256 P1, uint256 P2, uint256 P3)
     {
         unchecked {
-            assembly {
+            assembly ("memory-safe") {
                 P0 := mulmod(2, y, p) //U = 2*Y1
                 P2 := mulmod(P0, P0, p) // V=U^2
                 P3 := mulmod(x, P2, p) // S = X1*V
@@ -255,7 +255,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
                 return (x2, y2, 1, 1);
             }
 
-            assembly {
+            assembly ("memory-safe") {
                 y1 := sub(p, y1)
                 y2 := addmod(mulmod(y2, zzz1, p), y1, p)
                 x2 := addmod(mulmod(x2, zz1, p), sub(p, x1), p)
@@ -365,7 +365,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
                 scalar_v=0;
 
             }
-            assembly {
+            assembly ("memory-safe") {
                 for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
                     index := sub(index, 1)
                     T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
@@ -521,7 +521,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
 
             (H[0], H[1]) = ecAff_add(gx, gy, Q0, Q1); //will not work if Q=P, obvious forbidden private key
 
-            assembly {
+            assembly ("memory-safe") {
                 for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {
                     index := sub(index, 1)
                     T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1))
@@ -679,7 +679,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
                             + 2 * ((scalar_u >> (zz - 128)) & 1) + ((scalar_u >> (zz - 192)) & 1)
                     );
             }
-            assembly {
+            assembly ("memory-safe") {
                 extcodecopy(dataPointer, T, mload(T), 64)
                 let index := sub(zz, 1)
                 X := mload(T)
@@ -824,7 +824,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
                             + 2 * ((scalar_u >> (zz - 128)) & 1) + ((scalar_u >> (zz - 192)) & 1)
                     );
             }
-            assembly {
+            assembly ("memory-safe") {
                 codecopy(T, add(mload(T), dataPointer), 64)
                 X := mload(T)
                 let Y := mload(add(T, 32))
@@ -938,7 +938,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
         //Shamir 8 dimensions
         X = ecZZ_mulmuladd_S8_hackmem(mulmod(uint256(message), sInv, n), mulmod(r, sInv, n), endcontract);
 
-        assembly {
+        assembly ("memory-safe") {
             X := addmod(X, sub(n, r), n)
         }
         return X == 0;

--- a/solidity/src/FCL_sha512.sol
+++ b/solidity/src/FCL_sha512.sol
@@ -177,9 +177,9 @@ library sha512 {
     function k512(uint j) internal view returns (uint64 r)
     {
         uint256[1] memory T;
-         assembly{
-        extcodecopy(0xcaca, T, mul(j,8), 8)
-    }
+        assembly ("memory-safe") {
+            extcodecopy(0xcaca, T, mul(j,8), 8)
+        }
         r=uint64(T[0]>>192);
 
         return r;
@@ -284,7 +284,7 @@ function SHA512(uint64[16] memory data) internal view returns(uint256 low, uint2
  unchecked{       
  do {
           
-assembly{
+assembly ("memory-safe") {
             let T1:= mload(add(data,mul(32,j))) // buffer[j] =T1= (data[j]);   
             
             mstore(add(buffer, mul(32,j)), T1)    
@@ -318,7 +318,7 @@ assembly{
             /* Part of the message block expansion: */
             //uint64 T1 = buffer[(j + 1) & 0x0f];
             uint64 T1;uint64 T2;
-               assembly{
+               assembly ("memory-safe") {
                 T1:= mload(add(buffer, mul(32,and(0x0f, add(j,1)))))   
                   T1:=  xor(xor( or(shr(1,T1), shl(63,T1)) , or(shr(8,T1), shl(56,T1))), shr(7,T1)     ) 
                 T2:=mload(add(buffer, mul(32,and(0x0f, add(j,14)))))   

--- a/solidity/src/utils/Base64Url.sol
+++ b/solidity/src/utils/Base64Url.sol
@@ -21,7 +21,7 @@ library Base64Url {
         string memory result = new string(4 * ((data.length + 2) / 3));
 
         // @solidity memory-safe-assembly
-        assembly {
+        assembly ("memory-safe") {
             let tablePtr := add(table, 1)
             let resultPtr := add(result, 32)
 


### PR DESCRIPTION
This PR just tags all assembly blocks as `memory-safe`. Non-memory-safe assembly causes the Solidity compiler to disallow some Yul optimizations for the entire compilation unit.

I checked when marking the assembly blocks and I believe that they are all memory-safe (just not tagged as such).

For reference, assembly is considered memory-safe if ([reference](https://docs.soliditylang.org/en/v0.8.23/assembly.html#memory-safety):

> * Memory allocated by yourself using a mechanism like the `allocate` function described above.
> * Memory allocated by Solidity, e.g. memory within the bounds of a memory array you reference.
> * The scratch space between memory offset 0 and 64 mentioned above.
> * Temporary memory that is located after the value of the free memory pointer at the beginning of the assembly block, i.e. memory that is “allocated” at the free memory pointer without updating the free memory pointer.
