### PR TITLE
Fix operand in ecAff_isOnCurve

### DIFF
--- a/solidity/src/FCL_elliptic.sol
+++ b/solidity/src/FCL_elliptic.sol
@@ -306,7 +306,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
      * @dev Check if a point in affine coordinates is on the curve (reject Neutral that is indeed on the curve).
      */
     function ecAff_isOnCurve(uint256 x, uint256 y) internal pure returns (bool) {
-        if ( ((0 == x)&&( 0 == y)) || x == p ||   y == p) {
+        if ( ((0 == x)&&( 0 == y)) || (x == p &&  y == p)) {
             return false;
         }
         unchecked {


### PR DESCRIPTION
During a call between @rdubois-crypto and the Base team, we determined that the operand in ecAff_isOnCurve should be an `&&` instead of an `||`. This PR implements that change. 