### PR TITLE
Add additional check to avoid infinite loop

### DIFF
--- a/solidity/src/FCL_elliptic.sol
+++ b/solidity/src/FCL_elliptic.sol
@@ -363,7 +363,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
             {
                 scalar_u=addmod(scalar_u, n-scalar_v, n);
                 scalar_v=0;
-
+                if (scalar_u == 0 && scalar_v == 0) return 0;
             }
             assembly {
                 for { let T4 := add(shl(1, and(shr(index, scalar_v), 1)), and(shr(index, scalar_u), 1)) } eq(T4, 0) {


### PR DESCRIPTION
**Issue:** 
If we call `ecZZ_mulmuladd_S_asm( -Gx, -Gy, 1, 1)` then the current implementation hangs indefinitely in the for loop: 
https://github.com/rdubois-crypto/FreshCryptoLib/blob/027cb877dc78640b62e25fce63eccee102ac828d/solidity/src/FCL_elliptic.sol#L369-L372

This occurs because the method currently checks for `u == 0 and v ==0` before determining `if((H0==0)&&(H1==0))`. With coordinates `-Gx` and `-Gy`, this check is true which results in both `u` and `v` being set to 0. Then the loop referenced above searches for the MSB of 0. 

**Fix:**
We can easily address this by re-checking if `u == v == 0` and returning early inside this specific condition. 