### PR TITLE
Fix ecAff_isOnCurve

### DIFF
--- a/solidity/src/FCL_elliptic.sol
+++ b/solidity/src/FCL_elliptic.sol
@@ -306,7 +306,7 @@ function SqrtMod(uint256 self) internal view returns (uint256 result){
      * @dev Check if a point in affine coordinates is on the curve (reject Neutral that is indeed on the curve).
      */
     function ecAff_isOnCurve(uint256 x, uint256 y) internal pure returns (bool) {
-        if ((0 == x % p) && (0 == y % p)) {
+        if (x >= p || y >= p || ((x == 0) && (y == 0))) {
             return false;
         }
         unchecked {

--- a/solidity/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
@@ -50,6 +50,24 @@ contract ArithmeticTest is Test {
     uint256 constant _NUM_TEST_ECMULMULADD = 1000;
     uint256 constant _NUM_TEST_DBL = 100;
 
+    function test_ecAff_isOnCurve_returnsFalse_whenX0() public {
+        assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(0, gy));
+    }
+
+    function test_ecAff_isOnCurve_returnsFalse_whenY0() public {
+        assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(gx, 0));
+    }
+
+    function test_ecAff_isOnCurve_returnsFalse_whenXGreaterThanEqualP(uint x) public {
+        vm.assume(x >= p);
+        assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(x, gy));
+    }
+
+    function test_ecAff_isOnCurve_returnsFalse_whenYGreaterThanEqualP(uint y) public {
+        vm.assume(y >= p);
+        assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(gx, y));
+    }
+
     function test_Fuzz_InVmodn(uint256 i_u256_a) public {
         vm.assume(i_u256_a < FCL_Elliptic_ZZ.n);
         vm.assume(i_u256_a != 0);

--- a/solidity/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
+++ b/solidity/tests/WebAuthn_forge/test/FCL_elliptic.t.sol
@@ -58,12 +58,12 @@ contract ArithmeticTest is Test {
         assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(gx, 0));
     }
 
-    function test_ecAff_isOnCurve_returnsFalse_whenXGreaterThanEqualP(uint x) public {
+    function test_ecAff_isOnCurve_returnsFalse_whenXGreaterThanEqualP(uint256 x) public {
         vm.assume(x >= p);
         assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(x, gy));
     }
 
-    function test_ecAff_isOnCurve_returnsFalse_whenYGreaterThanEqualP(uint y) public {
+    function test_ecAff_isOnCurve_returnsFalse_whenYGreaterThanEqualP(uint256 y) public {
         vm.assume(y >= p);
         assertFalse(FCL_Elliptic_ZZ.ecAff_isOnCurve(gx, y));
     }


### PR DESCRIPTION
Further to #65 

> The description of the PR is correct in pointing out that the code accepts x and x+p < 2^256 (and similarly y and y+p < 2^256) as valid while it should only accept x and y. I believe the fix should be adding an additional check that validates if x < p && y < p. Putting it all together, I think the following change should be made:

https://github.com/rdubois-crypto/FreshCryptoLib/pull/65#issuecomment-2037277371